### PR TITLE
Enhancement: Add PHP 7.3 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
     - php: 7.2
       env: COMPOSER_FLAGS=--prefer-lowest
     - php: 7.2
+    - php: 7.3
+      env: COMPOSER_FLAGS=--prefer-lowest
+    - php: 7.3
 
 branches:
   only:

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^7.1",
         "doctrine/common": ">=2.2.1,<=2.10-dev",
         "doctrine/dbal": ">=2.2.1,<=2.9-dev",
-        "doctrine/orm": ">=2.2.1,<3.0-dev"
+        "doctrine/orm": ">=2.6.3,<3.0-dev"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14.0",


### PR DESCRIPTION
This PR

* [x] adds PHP 7.3 to the Travis build matrix
* [x] adjusts the version constraints for `doctrine/orm`

💁‍♂️ For the latter change, see https://github.com/doctrine/orm/pull/7325.