### PR TITLE
Enhancement: Add PHP 7.4 to the build matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -64,6 +64,7 @@ jobs:
           - "7.1"
           - "7.2"
           - "7.3"
+          - "7.4"
 
         dependencies:
           - "lowest"

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     },
     "require": {
         "php": "^7.1",
+        "doctrine/annotations": "^1.7.0",
         "doctrine/common": "^2.2.1",
         "doctrine/dbal": "^2.2.1",
         "doctrine/orm": "^2.6.3"


### PR DESCRIPTION
This PR

* [x] adds PHP 7.4 to the build matrix
* [x] requires `doctrine/annotations:^1.7.0` (see https://github.com/doctrine/annotations/issues/273)