### PR TITLE
Enhancement: Throw exception when entity definition for name is unavailable

### DIFF
--- a/src/Provider/Doctrine/EntityDefinitionUnavailable.php
+++ b/src/Provider/Doctrine/EntityDefinitionUnavailable.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FactoryGirl\Provider\Doctrine;
+
+final class EntityDefinitionUnavailable extends \OutOfRangeException implements Exception
+{
+    public static function for(string $name): self
+    {
+        return new self(sprintf(
+            'An entity definition for name "%s" is not available.',
+            $name
+        ));
+    }
+}

--- a/tests/Provider/Doctrine/EntityDefinitionUnavailableTest.php
+++ b/tests/Provider/Doctrine/EntityDefinitionUnavailableTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FactoryGirl\Tests\Provider\Doctrine;
+
+use FactoryGirl\Provider\Doctrine\EntityDefinitionUnavailable;
+use PHPUnit\Framework;
+
+/**
+ * @covers \FactoryGirl\Provider\Doctrine\EntityDefinitionUnavailable
+ */
+final class EntityDefinitionUnavailableTest extends Framework\TestCase
+{
+    public function testForReturnsException(): void
+    {
+        $name = 'foo';
+
+        $exception = EntityDefinitionUnavailable::for($name);
+
+        self::assertInstanceOf(\OutOfRangeException::class, $exception);
+
+        $message = sprintf(
+            'An entity definition for name "%s" is not available.',
+            $name
+        );
+
+        self::assertSame($message, $exception->getMessage());
+    }
+}

--- a/tests/Provider/Doctrine/FixtureFactoryTest.php
+++ b/tests/Provider/Doctrine/FixtureFactoryTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FactoryGirl\Tests\Provider\Doctrine;
+
+use Doctrine\ORM\EntityManager;
+use FactoryGirl\Provider\Doctrine\EntityDefinitionUnavailable;
+use FactoryGirl\Provider\Doctrine\FixtureFactory;
+
+use PHPUnit\Framework;
+
+/**
+ * @covers \FactoryGirl\Provider\Doctrine\FixtureFactory
+ */
+final class FixtureFactoryTest extends Framework\TestCase
+{
+    public function testGetThrowsEntityDefinitionUnavailableWhenDefinitionIsUnavailable(): void
+    {
+        $entityManager = $this->prophesize(EntityManager::class)->reveal();
+
+        $fixtureFactory = new FixtureFactory($entityManager);
+
+        $this->expectException(EntityDefinitionUnavailable::class);
+
+        $fixtureFactory->get('foo');
+    }
+}


### PR DESCRIPTION
This PR

* [x] throws an `EntityDefinitionUnavailable` exception when an entity definition for a name is not available

